### PR TITLE
Changes to update container to LFRic vn2.0

### DIFF
--- a/files/psyclone_new.cfg
+++ b/files/psyclone_new.cfg
@@ -77,6 +77,25 @@ supported_fortran_datatypes = real, integer, logical
 # Specify default kind (precision) for the supported LFRic data types
 default_kind = real: r_def, integer: i_def, logical: l_def
 
+# Specify number of bytes for the supported LFRic data types.
+# The values for 'r_tran', 'r_solver', 'r_def', 'r_bl' and 'r_phys' are
+# set according to CPP ifdefs. The values given below are the defaults.
+# 'l_def' is included in this dict so that it contains a complete
+# record of the various precision symbols used in LFRic.
+precision_map = i_def: 4,
+                l_def: 1,
+                r_def: 8,
+                r_double: 8,
+                r_ncdf: 8,
+                r_quad: 16,
+                r_second: 8,
+                r_single: 4,
+                r_solver: 4,
+                r_tran: 8,
+                r_bl: 8,
+                r_phys: 8,
+                r_um: 8
+                
 # Specify whether we generate code to perform runtime correctness checks
 RUN_TIME_CHECKS = false
 

--- a/lfric_env.def
+++ b/lfric_env.def
@@ -107,7 +107,7 @@ dnf -y install gcc-gfortran
 
 #hdf5
 cd $BUILD_DIR
-wget http://www.hdfgroup.org/ftp/HDF5/prev-releases/hdf5-1.12/hdf5-$HDF5/src/hdf5-$HDF5.tar.gz
+wget https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/downloads/hdf5-$HDF5.tar.gz
 tar -xzf hdf5-$HDF5.tar.gz
 cd $BUILD_DIR/hdf5-$HDF5
 CC=mpicc FC=mpif90 ./configure --prefix=$NETCDF_DIR --enable-fortran --enable-fortran2003 --enable-parallel

--- a/lfric_gcc.def
+++ b/lfric_gcc.def
@@ -43,9 +43,9 @@ HDF5=1.14.5
 NETCDF4=4.9.2
 NETCDF_FORTRAN=4.5.3
 NETCDF_CXX=4.2
-YAXT=0.9.2.1
+YAXT=0.11.3
 PFUNIT=4.10.0
-PSYCLONE=2.5.0
+PSYCLONE=3.0.0
 
 #fcm
 cd $BASE_DIR
@@ -140,20 +140,14 @@ make install
 
 export LIBS='-lnetcdff -lnetcdf -lhdf5_hl -lhdf5'
 
+
 #yaxt
 cd $BUILD_DIR
-wget https://swprojects.dkrz.de/redmine/attachments/download/515/yaxt-$YAXT.tar.gz
+wget https://swprojects.dkrz.de/redmine/attachments/download/541/yaxt-$YAXT.tar.gz
 tar -xzf yaxt-$YAXT.tar.gz
 cd $BUILD_DIR/yaxt-$YAXT
-#CC='mpicc' FC='mpif90'
-./configure --prefix=$INSTALL_DIR --with-idxtype=long CC=mpicc FC=mpif90 FPP="mpif90 -E -cpp" --enable-static=yes --enable-shared=false --without-regard-for-quality
-#wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O $BUILD_DIR/yaxt-0.9.0#/config/config.guess
-#wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'  -O $BUILD_DIR/yaxt-0.9.0/#config/config.sub
-#./yaxt-0.9.0/configure --prefix=$INSTALL_DIR --with-idxtype=long CC=mpicc FC=mpif90 FPP="mpif90 -E -cpp"
-#make
-#make check
-#make install
-make -j $NCORES
+./configure --prefix=$INSTALL_DIR --with-idxtype=long CC=mpicc FC=mpif90 FPP="mpif90 -E -cpp"
+make -j$NCORES
 make install
 
 
@@ -161,7 +155,7 @@ make install
 cd $BUILD_DIR
 export NETCDF_DIR
 export HDF5_DIR=$NETCDF_DIR 
-svn --non-interactive  --trust-server-cert-failures=cn-mismatch co http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk@2252 XIOS 
+svn --non-interactive --trust-server-cert-failures=cn-mismatch co https://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk@2252 XIOS 
 cd $BUILD_DIR/XIOS
 MY_FFLAGS="-ffree-line-length-200"
 cp arch/arch-GCC_LINUX.fcm arch/arch-GCC_LINUX.fcm.original
@@ -203,6 +197,11 @@ rm -fr $BUILD_DIR
 python3 -m pip install --no-cache-dir  --upgrade pip
 #python3 -m pip install --upgrade setuptools
 python3 -m pip install Jinja2
+# JE - instead of using release version of PSyclone, use the latest commit to main 
+# as the release versions can be out of date
+#git clone --recursive https://github.com/stfc/PSyclone.git
+#cd PSyclone
+#pip install .[psydata]
 python3 -m pip install PSyclone==$PSYCLONE
 python3 -m pip install scitools-iris
 python3 -m pip install geovista
@@ -210,7 +209,6 @@ python3 -m pip install esmf_regrid
 python3 -m pip install ipython
 ln -s /usr/bin/python3 $INSTALL_DIR/bin/python
 mv /opt/psyclone_new.cfg /container/psyclone_new.cfg
-
 
 %environment
 
@@ -224,6 +222,7 @@ export CPPFLAGS="-I$INSTALL_DIR/include -I$NETCDF_DIR/include"
 export FFLAGS="-I$INSTALL_DIR/include -I$INSTALL_DIR/mod -I$NETCDF_DIR/include -I$MPICH_DIR/include"
 export LDFLAGS="-L$INSTALL_DIR/lib -L$NETCDF_DIR/lib"
 export PATH=$NETCDF_DIR/bin:$INSTALL_DIR/bin:$BASE_DIR/fcm/bin/:$MPICH_DIR/bin:$PATH
+# JE - use up-to-date PSyclone from git repo directly
 export PSYCLONE_CONFIG=/container/psyclone_new.cfg
 export CYLC_VERSION=8
 #Library path

--- a/lfric_gcc.def
+++ b/lfric_gcc.def
@@ -35,17 +35,17 @@ mkdir -p $BUILD_DIR
 NCORES=8
 
 FCM_VERSION=2021.05.0
-CYLC_VERSION=8
+CYLC_VERSION=8.3.4
 ROSE_VERSION=2.1.0
 
 MPICH=4.2.1
-HDF5=1.13.3
+HDF5=1.14.5
 NETCDF4=4.9.2
 NETCDF_FORTRAN=4.5.3
 NETCDF_CXX=4.2
 YAXT=0.9.2.1
-PFUNIT=3.2.9
-PSYCLONE=2.4.0
+PFUNIT=4.10.0
+PSYCLONE=2.5.0
 
 #fcm
 cd $BASE_DIR
@@ -72,10 +72,10 @@ python3 -m pip install tornado
 
 
 export NETCDF_DIR=$BASE_DIR/netcdf
-export MPICH_DIR=$/BASE_DIR/mpich
+export MPICH_DIR=$BASE_DIR/mpich
 export INSTALL_DIR=$BASE_DIR/usr
 export CPPFLAGS="-I$INSTALL_DIR/include -I$NETCDF_DIR/include"
-export FFLAGS="-I$INSTALL_DIR/mpich/include -I$INSTALL_DIR/include -I$NETCDF_DIR/include"
+export FFLAGS="-I$MPICH_DIR/include -I$INSTALL_DIR/include -I$NETCDF_DIR/include"
 export LDFLAGS="-L$INSTALL_DIR/lib -L$NETCDF_DIR/lib"
 export PATH=$MPICH_DIR/bin:$NETCDF_DIR/bin:$INSTALL_DIR/bin:$PATH
 export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$NETCDF_DIR/lib:$INSTALL_DIR/lib:$LD_LIBRARY_PATH
@@ -95,7 +95,7 @@ export PATH=/container/mpich/bin/:$PATH
 
 #hdf5
 cd $BUILD_DIR
-wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-$HDF5/src/hdf5-$HDF5.tar.gz
+wget https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/downloads/hdf5-${HDF5}.tar.gz
 tar -xzf hdf5-$HDF5.tar.gz
 cd $BUILD_DIR/hdf5-$HDF5
 CC=mpicc FC=mpif90 ./configure --prefix=$NETCDF_DIR --enable-shared --enable-fortran --enable-fortran2003 --enable-parallel --enable-hl --enable-shared --enable-static --with-zlib --with-szlib=/usr/local 
@@ -142,7 +142,7 @@ export LIBS='-lnetcdff -lnetcdf -lhdf5_hl -lhdf5'
 
 #yaxt
 cd $BUILD_DIR
-wget https://www.dkrz.de/redmine/attachments/download/515/yaxt-$YAXT.tar.gz
+wget https://swprojects.dkrz.de/redmine/attachments/download/515/yaxt-$YAXT.tar.gz
 tar -xzf yaxt-$YAXT.tar.gz
 cd $BUILD_DIR/yaxt-$YAXT
 #CC='mpicc' FC='mpif90'
@@ -161,7 +161,7 @@ make install
 cd $BUILD_DIR
 export NETCDF_DIR
 export HDF5_DIR=$NETCDF_DIR 
-svn co http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk@2252 XIOS 
+svn --non-interactive  --trust-server-cert-failures=cn-mismatch co http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk@2252 XIOS 
 cd $BUILD_DIR/XIOS
 MY_FFLAGS="-ffree-line-length-200"
 cp arch/arch-GCC_LINUX.fcm arch/arch-GCC_LINUX.fcm.original
@@ -183,14 +183,13 @@ cp bin/* $INSTALL_DIR/bin
 
 #pFUnit
 cd $BUILD_DIR
-wget https://sourceforge.net/projects/pfunit/files/latest/download/pFUnit-$PFUNIT.tgz
-tar -xzf pFUnit-$PFUNIT.tgz
-cd pFUnit-$PFUNIT
+git clone --recursive https://github.com/Goddard-Fortran-Ecosystem/pFUnit
+cd pFUnit
 export F90_VENDOR=gnu
 export F90=gfortran
 export MPIF90=mpif90
 #Hack for python2
-cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=YES -DOPENMP=YES -DROBUST=YES -DMAX_RANK=6 ../pFUnit-3.2.9
+cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=YES -DOPENMP=YES -DROBUST=YES -DMAX_RANK=6 ../pFUnit
 make -j $NCORES
 make tests
 make install
@@ -226,7 +225,7 @@ export FFLAGS="-I$INSTALL_DIR/include -I$INSTALL_DIR/mod -I$NETCDF_DIR/include -
 export LDFLAGS="-L$INSTALL_DIR/lib -L$NETCDF_DIR/lib"
 export PATH=$NETCDF_DIR/bin:$INSTALL_DIR/bin:$BASE_DIR/fcm/bin/:$MPICH_DIR/bin:$PATH
 export PSYCLONE_CONFIG=/container/psyclone_new.cfg
-
+export CYLC_VERSION=8
 #Library path
 export LD_LIBRARY_PATH="$LOCAL_LD_LIBRARY_PATH:/lib:$NETCDF_DIR/lib:$INSTALL_DIR/lib:$LD_LIBRARY_PATH:/usr/lib64:/usr/lib64/libibverbs:/usr/lib/host:/lib/x86_64-linux-gnu"
 


### PR DESCRIPTION
Some minor changes to installs/versions, and updated paths to some of the dependencies where these had changed since inital work. 

I have tested this with a local build and run of the LFRic_atm single column model - further testing with more complicated cases (specifically cases using multiple MPI ranks and OpenMP) to follow